### PR TITLE
Fix showable-password display quirks on Safari

### DIFF
--- a/packages/pw-component-showable-password/index.js
+++ b/packages/pw-component-showable-password/index.js
@@ -42,9 +42,7 @@ class Password extends React.Component {
     return (
       <div {...omit(props, ['styles', 'showing'])} styleName="base">
         <Input {...inputProps} />
-        <button type="button" styleName={addonStyle} onClick={toggleShow}>
-          Show
-        </button>
+        <a tabIndex="0" styleName={addonStyle} onClick={toggleShow}>Show</a>
       </div>
     );
   }

--- a/packages/pw-component-showable-password/style.css
+++ b/packages/pw-component-showable-password/style.css
@@ -27,7 +27,10 @@
     @apply --default-icon-size;
 
     font-family: fontello;
-    margin-right: 0.5rem;
+    margin-right: var(--tinySpacing);
+
+    /* This is padded down due to the font not being totally vertically aligned, not a CSS problem */
+    padding-top: 0.1rem;
     transition: color 0.1s;
   }
 }

--- a/packages/pw-component-showable-password/tests/index.js
+++ b/packages/pw-component-showable-password/tests/index.js
@@ -45,11 +45,11 @@ describe('<Password />', () => {
       <Password value="password" />
     );
 
-    renderedComponent.find('button').simulate('click');
+    renderedComponent.find('a').simulate('click');
     expect(renderedComponent.state().showing).toEqual(true);
     expect(renderedComponent.find(Input).props().type).toEqual('text');
 
-    renderedComponent.find('button').simulate('click');
+    renderedComponent.find('a').simulate('click');
     expect(renderedComponent.state().showing).toEqual(false);
     expect(renderedComponent.find(Input).props().type).toEqual('password');
   });


### PR DESCRIPTION
WebKit doesn't respect display:flex rules properly on button. Converting
it to anchor element fixes it.