### PR TITLE
Enable es2015 modules

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,6 +40,9 @@
       ],
       "react",
       "stage-0"
+    ],
+    "plugins": [
+      "syntax-dynamic-import"
     ]
   },
   "eslintConfig": {
@@ -162,6 +165,7 @@
     }
   },
   "dependencies": {
+    "babel-plugin-syntax-dynamic-import": "^6.18.0",
     "babel-polyfill": "^6.16.0",
     "lodash": "^4.16.4",
     "postcss-font-awesome": "^0.3.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -646,6 +646,10 @@ babel-plugin-syntax-do-expressions@^6.8.0:
   version "6.13.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-syntax-do-expressions/-/babel-plugin-syntax-do-expressions-6.13.0.tgz#5747756139aa26d390d09410b03744ba07e4796d"
 
+babel-plugin-syntax-dynamic-import@^6.18.0:
+  version "6.18.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-syntax-dynamic-import/-/babel-plugin-syntax-dynamic-import-6.18.0.tgz#8d6a26229c83745a9982a441051572caa179b1da"
+
 babel-plugin-syntax-exponentiation-operator@^6.8.0:
   version "6.13.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-syntax-exponentiation-operator/-/babel-plugin-syntax-exponentiation-operator-6.13.0.tgz#9ee7e8337290da95288201a6a57f4170317830de"


### PR DESCRIPTION
Because apparently they were disabled, though only Jest seemed to care.