### PR TITLE
Update verson number to 0.0.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pw-uikit",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "A modular React components system that leverages CSS modules for styling.",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Needs to happen to trigger yarn to actually update the codebase
(noticing CircleCI was still using the old code on pw-react build).